### PR TITLE
[PRPL-1189] Update the default host maps in preparation for generated friendly hosts.

### DIFF
--- a/moov_config-dev.json
+++ b/moov_config-dev.json
@@ -11,7 +11,7 @@
   },
   "layers": ["minify-js", "minify-css", "live-reload"],
   "host_map": [
-    "react-storefront-boilerplate.moovdemos.com => dev-origin.moovweb.com"
+    "$.moovweb.cloud => dev-origin.moovweb.com"
   ],
   "static_paths": {
     "/manifest.json": "/manifest.json",

--- a/moov_config-prod.json
+++ b/moov_config-prod.json
@@ -11,7 +11,7 @@
   },
   "layers": ["minify-js", "minify-css", "live-reload"],
   "host_map": [
-    "$.www.moovweb.com => origin.moovweb.com"
+    "$.moovweb.cloud => origin.moovweb.com"
   ],
   "static_paths": {
     "/manifest.json": "/manifest.json",


### PR DESCRIPTION
After https://github.com/moovweb/apollo/pull/1484 is deployed, this change will create Heroku-style URLs automatically.