### PR TITLE
Minor cleanup items

### DIFF
--- a/src/ErrorPage.js
+++ b/src/ErrorPage.js
@@ -7,7 +7,7 @@ import Redbox from 'react-storefront/Redbox'
 export default class ErrorPage extends Component {
   render() {
     if (process.env.MOOV_ENV === 'production') {
-      // In production we return a generic, user-friendlt error page that hides the underlying message and stacktrack
+      // In production we return a generic, user-friendly error page that hides the underlying message and stacktrace
       return (
         <Container>
           <Row>

--- a/src/category/Category.js
+++ b/src/category/Category.js
@@ -35,12 +35,11 @@ import Breadcrumbs from 'react-storefront/Breadcrumbs'
     image: {
       width: '100%'
     }
-  }),
-  { name: 'RSFDemoCategory' }
+  })
 )
 @inject(({ app }) => ({ category: app.category }))
 @observer
-export default class App extends Component {
+export default class Category extends Component {
   render() {
     const { category, classes } = this.props
 

--- a/src/subcategory/ProductItem.js
+++ b/src/subcategory/ProductItem.js
@@ -28,7 +28,7 @@ import Track from 'react-storefront/Track'
       color: 'inherit'
     },
     price: {
-      color: theme.palette.price,
+      color: theme.palette.price.main,
       marginTop: '5px'
     },
     reviews: {
@@ -37,8 +37,7 @@ import Track from 'react-storefront/Track'
     reviewCount: {
       marginLeft: '2px'
     }
-  }),
-  { name: 'RSFProductItem' }
+  })
 )
 export default class ProductItem extends Component {
   static propTypes = {

--- a/src/subcategory/Subcategory.js
+++ b/src/subcategory/Subcategory.js
@@ -39,8 +39,7 @@ import LoadMask from 'react-storefront/LoadMask'
       marginTop: `${theme.margins.container - 5}px`,
       width: '200px'
     }
-  }),
-  { name: 'RSFSubcategory' }
+  })
 )
 @inject(({ app }) => ({ subcategory: app.subcategory }))
 @observer

--- a/src/theme.js
+++ b/src/theme.js
@@ -10,7 +10,7 @@ const theme = createTheme({
       main: red[700],
       light: red[600],
       dark: red[800],
-      contrasText: '#fff'
+      contrastText: '#fff'
     },
     spacing: {
       container: 15,

--- a/src/theme.js
+++ b/src/theme.js
@@ -11,6 +11,11 @@ const theme = createTheme({
       light: red[600],
       dark: red[800],
       contrastText: '#fff'
+    },
+    price: {
+      full: '#000',
+      main: '#000',
+      sale: '#900'
     }
   },
   spacing: {

--- a/src/theme.js
+++ b/src/theme.js
@@ -11,11 +11,11 @@ const theme = createTheme({
       light: red[600],
       dark: red[800],
       contrastText: '#fff'
-    },
-    spacing: {
-      container: 15,
-      row: 15
     }
+  },
+  spacing: {
+    container: 15,
+    row: 15
   },
   overrides: {
     RSFLoadMask: {


### PR DESCRIPTION
Just a few cleanup items here:
1. Remove `yarn.lock` (not needed for RSF 6+, using `npm` now)
2. ~~Move some `devDependencies` into `dependencies`, if those libs are directly used in the code (makes merging this upstream repo into the PS boilerplate smoother)~~
3. Remove the overridable theme `name` property from `withStyles()`'s second parameter (this was probably copy/pasted by accident)
4. Fix class name for `Category`
5. Fix theme's `contrastText` typo
6. Move theme's `spacing` into proper hierarchy