### PR TITLE
Use display:block around ImageSwitcher in AMP to fix issue where imag…

### DIFF
--- a/src/product/Product.js
+++ b/src/product/Product.js
@@ -27,7 +27,7 @@ export const styles = theme => ({
     display: 'flex',
     flexDirection: 'row',
     [theme.breakpoints.down('xs')]: {
-      flexDirection: 'column'
+      display: 'block' 
     }
   },
   imageSwitcher: {


### PR DESCRIPTION
…es sometimes don't show.