### PR TITLE
[PC-308] Start webpack build before everything else

### DIFF
--- a/tasks/on_project_start
+++ b/tasks/on_project_start
@@ -1,7 +1,7 @@
 const builder = require("moov_builder");
 
 // Run webpack before everything else
-builder.Bundler.watch();
+builder.bundler.watch();
 
 // Run gulp tasks
 builder().watch();

--- a/tasks/on_project_start
+++ b/tasks/on_project_start
@@ -1,1 +1,7 @@
-require("moov_builder")().watch();
+const builder = require("moov_builder");
+
+// Run webpack before everything else
+builder.Bundler.watch();
+
+// Run gulp tasks
+builder().watch();

--- a/tasks/on_project_start
+++ b/tasks/on_project_start
@@ -1,7 +1,3 @@
 const builder = require("moov_builder");
 
-// Run webpack before everything else
-builder.bundler.watch();
-
-// Run gulp tasks
-builder().watch();
+builder.buildAndWatch();


### PR DESCRIPTION
Run `bundler.watch` before `moov_builder.watch()` in order to reduce CLI startup time.
See also https://github.com/moovweb/moov_builder/pull/71.