### PR TITLE
Add script to uninstall service worker.

### DIFF
--- a/moov_config-demo.json
+++ b/moov_config-demo.json
@@ -20,6 +20,8 @@
     "/workbox-*": "/workbox-*",
     "/icons/*": "/icons/*",
     "/robots.txt": "/robots.txt",
-    "/favicon.ico": "/icons/favicon.ico"
+    "/favicon.ico": "/icons/favicon.ico",
+    "/uninstall-service-worker.js": "/uninstall-service-worker/uninstall-service-worker.js",
+    "/noop-service-worker.js": "/uninstall-service-worker/noop-service-worker.js"
   }
 }

--- a/moov_config-dev.json
+++ b/moov_config-dev.json
@@ -20,6 +20,8 @@
     "/workbox-*": "/workbox-*",
     "/icons/*": "/icons/*",
     "/robots.txt": "/robots.txt",
-    "/favicon.ico": "/icons/favicon.ico"
+    "/favicon.ico": "/icons/favicon.ico",
+    "/uninstall-service-worker.js": "/uninstall-service-worker/uninstall-service-worker.js",
+    "/noop-service-worker.js": "/uninstall-service-worker/noop-service-worker.js"
   }
 }

--- a/moov_config-local.json
+++ b/moov_config-local.json
@@ -23,6 +23,5 @@
     "/favicon.ico": "/icons/favicon.ico",
     "/uninstall-service-worker.js": "/uninstall-service-worker/uninstall-service-worker.js",
     "/noop-service-worker.js": "/uninstall-service-worker/noop-service-worker.js"
-  },
-  "validate_amp": true
+  }
 }

--- a/moov_config-local.json
+++ b/moov_config-local.json
@@ -20,6 +20,9 @@
     "/workbox-*": "/workbox-*",
     "/icons/*": "/icons/*",
     "/robots.txt": "/robots.txt",
-    "/favicon.ico": "/icons/favicon.ico"
-  }
+    "/favicon.ico": "/icons/favicon.ico",
+    "/uninstall-service-worker.js": "/uninstall-service-worker/uninstall-service-worker.js",
+    "/noop-service-worker.js": "/uninstall-service-worker/noop-service-worker.js"
+  },
+  "validate_amp": true
 }

--- a/moov_config-prod.json
+++ b/moov_config-prod.json
@@ -20,6 +20,8 @@
     "/workbox-*": "/workbox-*",
     "/icons/*": "/icons/*",
     "/robots.txt": "/robots.txt",
-    "/favicon.ico": "/icons/favicon.ico"
+    "/favicon.ico": "/icons/favicon.ico",
+    "/uninstall-service-worker.js": "/uninstall-service-worker/uninstall-service-worker.js",
+    "/noop-service-worker.js": "/uninstall-service-worker/noop-service-worker.js"
   }
 }

--- a/public/uninstall-service-worker/index.html
+++ b/public/uninstall-service-worker/index.html
@@ -1,6 +1,0 @@
-<!DOCTYPE html>
-<html>
-  <body>
-    <script src="register-noop-service-worker.js"></script>
-  </body>
-</html>

--- a/public/uninstall-service-worker/index.html
+++ b/public/uninstall-service-worker/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="register-noop-service-worker.js"></script>
+  </body>
+</html>

--- a/public/uninstall-service-worker/noop-service-worker.js
+++ b/public/uninstall-service-worker/noop-service-worker.js
@@ -1,0 +1,15 @@
+self.addEventListener('install', function(event) {
+  self.skipWaiting()
+  console.log('[react-storefront] no-op service worker installed')
+})
+
+self.addEventListener('activate', event => {
+  event.waitUntil(clients.claim())
+  console.log('[react-storefront] no-op service worker has claimed all clients')
+
+  self.registration.unregister().then(function() {
+    console.log(
+      '[react-storefront] no-op service worker will be removed the next time the page reloads'
+    )
+  })
+})

--- a/public/uninstall-service-worker/noop-service-worker.js
+++ b/public/uninstall-service-worker/noop-service-worker.js
@@ -1,3 +1,9 @@
+/*
+ * This service worker immediately takes control away from  the existing service worker,
+ * then uninstall itself.  Technically it will be running until the next page reload, but it
+ * won't do anything.
+ */
+
 self.addEventListener('install', function(event) {
   self.skipWaiting()
   console.log('[react-storefront] no-op service worker installed')

--- a/public/uninstall-service-worker/uninstall-service-worker.js
+++ b/public/uninstall-service-worker/uninstall-service-worker.js
@@ -1,0 +1,7 @@
+/**
+ * Registers a service worker that does nothing except immediately
+ * take control of whatever service worker was previously installed.
+ */
+if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+  navigator.serviceWorker.register('/noop-service-worker.js')
+}


### PR DESCRIPTION
See https://moovweb.atlassian.net/browse/PC-768

This script can be used in A/B tests to ensure that the service worker is uninstalled when using the old experience.

It works by installing a no-op service worker in place of the existing service worker, immediately taking control of all browser tabs, then uninstalling itself.  Due to the nature of service workers, it will remaining running until the next page load, but essentially do nothing.