### PR TITLE
Matching PDP thumbnail image attributes

### DIFF
--- a/src/subcategory/ProductItem.js
+++ b/src/subcategory/ProductItem.js
@@ -69,6 +69,7 @@ export default class ProductItem extends Component {
             >
               <ProductLink prefetch="visible" className={classes.link} product={product}>
                 <ProductThumbnail
+                  quality={50}
                   lazy={index >= 4 && index < 10}
                   aspectRatio={100}
                   alt="product"


### PR DESCRIPTION
So PDP thumbnail can load immediately after being cached in the PLP